### PR TITLE
JUNIT-19: Update the validator library.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>nu.validator</groupId>
             <artifactId>validator</artifactId>
-            <version>17.11.1</version>
+            <version>18.11.5</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/src/java/fr/paris/lutece/test/Utils.java
+++ b/src/java/fr/paris/lutece/test/Utils.java
@@ -151,7 +151,7 @@ public class Utils
      */
     public static void validateHtmlFragment( String html ) throws IOException, SAXException
     {
-        validateHtml( "<!DOCTYPE html><title>junit</title>" + html, true );
+        validateHtml( "<!DOCTYPE html><html lang=fr><title>junit</title>" + html, true );
     }
 
     /**

--- a/src/test/java/fr/paris/lutece/test/UtilsTest.java
+++ b/src/test/java/fr/paris/lutece/test/UtilsTest.java
@@ -53,7 +53,7 @@ public class UtilsTest
     @Test
     public void testValidateHtml( ) throws IOException, SAXException
     {
-        Utils.validateHtml( "<!DOCTYPE html><title>junit</title><div>hello world</div>" );
+        Utils.validateHtml( "<!DOCTYPE html><html lang=en><title>junit</title><div>hello world</div>" );
     }
 
     @Test


### PR DESCRIPTION
See changelog : https://github.com/validator/validator/blob/master/CHANGELOG.md

Not using the 20.3.16 version because the maven artifact requires Java 9.