### PR TITLE
JUNIT-20: Add a lang attribute so as to not generate a warning

### DIFF
--- a/src/java/fr/paris/lutece/test/Utils.java
+++ b/src/java/fr/paris/lutece/test/Utils.java
@@ -156,7 +156,7 @@ public class Utils
      */
     public static void validateHtmlFragment( String html ) throws IOException, SAXException
     {
-        validateHtml( "<!DOCTYPE html><html lang=fr><title>junit</title>" + html, true );
+        validateHtmlFragment( html, true );
     }
 
     /**
@@ -175,7 +175,7 @@ public class Utils
      */
     public static void validateHtmlFragment( String html, boolean failOnWarning ) throws IOException, SAXException
     {
-        validateHtml( "<!DOCTYPE html><title>junit</title>" + html, failOnWarning );
+        validateHtml( "<!DOCTYPE html><html lang=fr><title>junit</title>" + html, failOnWarning );
     }
 
     /**


### PR DESCRIPTION
Consolidate the two versions of validateHtmlFragment so that they
use the same HTML prolog